### PR TITLE
Remove erroneous extra qualification on createRayTracingImplicitVar

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -371,7 +371,7 @@ public:
 
   /// Raytracing specific functions
   /// \brief Handle specific implicit declarations present only in raytracing stages
-  void DeclResultIdMapper::createRayTracingImplicitVar(const VarDecl *varDecl);
+  void createRayTracingImplicitVar(const VarDecl *varDecl);
 
 private:
   /// The struct containing SPIR-V information of a AST Decl.


### PR DESCRIPTION
There is an erroneous extra qualification on createRayTracingImplicitVar, which causes compilation errors under clang. (-fpermissive).

```
[1120/1152] Building CXX object tools/clang/lib/SPIRV/CMakeFiles/clangSPIRV.dir/SpirvEmitter.cpp.o
FAILED: tools/clang/lib/SPIRV/CMakeFiles/clangSPIRV.dir/SpirvEmitter.cpp.o
/usr/bin/c++  -DENABLE_SPIRV_CODEGEN -DSUPPORT_QUERY_GIT_COMMIT_INFO -D_GNU_SOURCE -D_ITERATOR_DEBUG_LEVEL=0 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Itools/clang/lib/SPIRV -I../tools/clang/lib/SPIRV -I../tools/clang/include -Itools/clang/include -Iinclude -I../include -Iinclude/dxc/Tracing -I../external/SPIRV-Headers/include -I../external/SPIRV-Tools/include -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-unknown-pragmas -fdiagnostics-color -std=c++11 -Wno-missing-field-initializers -pedantic -Wno-long-long -Wno-switch -Wno-maybe-uninitialized -Wnon-virtual-dtor -Wno-comment -std=c++11 -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -fno-strict-aliasing -O3 -DNDEBUG -MD -MT tools/clang/lib/SPIRV/CMakeFiles/clangSPIRV.dir/SpirvEmitter.cpp.o -MF tools/clang/lib/SPIRV/CMakeFiles/clangSPIRV.dir/SpirvEmitter.cpp.o.d -o tools/clang/lib/SPIRV/CMakeFiles/clangSPIRV.dir/SpirvEmitter.cpp.o -c ../tools/clang/lib/SPIRV/SpirvEmitter.cpp
In file included from ../tools/clang/lib/SPIRV/SpirvEmitter.h:37:0,
                 from ../tools/clang/lib/SPIRV/SpirvEmitter.cpp:14:
../tools/clang/lib/SPIRV/DeclResultIdMapper.h:374:8: error: extra qualification 'clang::spirv::DeclResultIdMapper::' on member 'createRayTracingImplicitVar' [-fpermissive]
   void DeclResultIdMapper::createRayTracingImplicitVar(const VarDecl *varDecl);
        ^~~~~~~~~~~~~~~~~~
```

This PR removes the extra qualification and allows for compilation to succeed.